### PR TITLE
Preparing a docker image with gcc-mingw

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*.md
+LICENSE

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,16 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag thearchitect:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:testing-slim
+
+RUN apt-get update && apt-get install -y \
+  gcc-mingw-w64 \
+  python3 \
+  python3-dev \
+  python3-pip \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY buildfolder/entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # thearchitect
+
+## docker
+
+In order to build the docker,
+
+```console
+docker build -t thearchitect .
+```
+
+In order to use the docker, for a `main.c` to compile available at `/tmp/data/main.c`, in order to get a `main.exe` under `/tmp/data/main.exe`,
+
+```console
+docker run --rm -v /tmp/data:/data thearchitect /data/main.c /data/main.exe
+```

--- a/buildfolder/entrypoint.sh
+++ b/buildfolder/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [[ -z "$1" ]]; then
+  echo "Missing first argument (input path)."
+  exit 1
+fi
+
+if [[ -z "$2" ]]; then
+  echo "Missing second argument (output path)."
+  exit 1
+fi
+
+x86_64-w64-mingw32-gcc -o "$2" "$1"


### PR DESCRIPTION
## Description
* PoC step 1, packaging docker-style gcc with cross-compilation for windows (MinGW).
* Adding a Dockerfile with the proper packages and an entrypoint forwarding to gcc-mingw.

## Related Issue
Closes #2 (PoC step 1).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Containerisation.

## How Has This Been Tested?
* Manually building and running the docker to compile windows-oriented C into an exe, and running the exe under windows.
* Adding a github action to try and test the image build at least

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

